### PR TITLE
Synchronize with distributed=1.15.2

### DIFF
--- a/Dockerfile-master
+++ b/Dockerfile-master
@@ -9,9 +9,6 @@ ENV PATH /opt/anaconda/bin:$PATH
 ENV PYTHONPATH /usr/lib/python2.7/site-packages/ 
 
 RUN conda update conda -y
-RUN conda install distributed dask pandas ipython protobuf pytest mock -y -q
+RUN conda install distributed=1.15.2 dask pandas ipython protobuf -y -q -c conda-forge
+RUN conda install pytest mock -y -q -c conda-forge
 RUN conda clean -pt -y
-
-# get latest dask/distributed
-RUN pip install git+https://github.com/dask/dask.git --upgrade
-RUN pip install git+https://github.com/dask/distributed.git --upgrade

--- a/Dockerfile-slave
+++ b/Dockerfile-slave
@@ -4,13 +4,10 @@ RUN apt-get install curl -y
 RUN curl -o miniconda.sh https://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh
 RUN bash miniconda.sh -f -b -p /opt/anaconda
 ENV PATH /opt/anaconda/bin:$PATH
+
 # location of mesos packages
 ENV PYTHONPATH /usr/lib/python2.7/site-packages/ 
 
 RUN conda update conda -y
-RUN conda install distributed dask pandas ipython protobuf -y -q
+RUN conda install distributed=1.15.2 dask pandas ipython protobuf -y -q -c conda-forge
 RUN conda clean -pt -y
-
-# get latest dask/distributed
-RUN pip install git+https://github.com/dask/dask.git --upgrade
-RUN pip install git+https://github.com/dask/distributed.git zict --upgrade

--- a/dask_marathon/core.py
+++ b/dask_marathon/core.py
@@ -13,7 +13,7 @@ logger = logging.getLogger(__file__)
 class MarathonCluster(object):
     def __init__(self, scheduler,
                  executable='dask-worker',
-                 docker_image='mrocklin/dask-distributed',
+                 docker_image='mrocklin/dask-distributed:1.15.2',
                  marathon_address='http://localhost:8080',
                  name=None, **kwargs):
         self.scheduler = scheduler
@@ -23,13 +23,14 @@ class MarathonCluster(object):
         args = [executable, scheduler.address,
                 '--name', '$MESOS_TASK_ID',  # use Mesos task ID as worker name
                 '--worker-port', '$PORT_WORKER',
+                '--bokeh-port', '$PORT_BOKEH',
                 '--nanny-port', '$PORT_NANNY',
                 '--http-port', '$PORT_HTTP']
 
         ports = [{'port': 0,
                   'protocol': 'tcp',
                   'name': name}
-                 for name in ['worker', 'nanny', 'http']]
+                 for name in ['worker', 'nanny', 'http', 'bokeh']]
 
         if 'mem' in kwargs:
             args.extend(['--memory-limit',

--- a/dask_marathon/tests/test_core.py
+++ b/dask_marathon/tests/test_core.py
@@ -16,56 +16,11 @@ for app in cg.list_apps():
 
 @gen_cluster(client=True, ncores=[], timeout=20)
 def test_simple(c, s):
-    with MarathonCluster(s, cpus=1, mem=256) as mc:
-        ac = Adaptive(s, mc)
-        ac.adapt()
-        yield gen.sleep(0.1)
-        assert not s.ncores
-
-        futures = c.map(lambda x: x + 1, range(10))
-        start = time()
-        while not s.ready:
+    with MarathonCluster(s, cpus=1, mem=1024) as mc:
+        mc.scale_up(1)
+        while len(s.workers) < 1:
             yield gen.sleep(0.01)
-            assert time() < start + 5
 
-        ac.adapt()
-
-        results = yield c._gather(futures)
-        assert s.transition_log
-
-        if s.worker_info:
-            tasks = mc.client.list_tasks(app_id=mc.app.id)
-            names = {d['name'] for d in s.worker_info.values()}
-            assert names == {t.id for t in tasks}
-
-        yield ac._retire_workers()
-
-        start = time()
-        while len(s.worker_info) > 1:
+        mc.scale_down(s.workers)
+        while s.workers:
             yield gen.sleep(0.01)
-            assert time() < start + 5
-
-        assert len(s.who_has) == len(futures)
-
-
-def test_sync(loop):
-    from threading import Thread
-    thread = Thread(target=loop.start); thread.daemon = True
-    thread.start()
-    from distributed import Scheduler
-    s = Scheduler(loop=loop)
-    s.start(0)
-    with MarathonCluster(s, cpus=1, mem=1000) as mc:
-        ac = Adaptive(s, mc)
-        with Client(s.address, loop=loop) as c:
-            assert not s.ncores
-            x = c.submit(lambda x: x + 1, 1)
-            x.result()
-            assert len(s.ncores) == 1
-
-            del x
-
-            start = time()
-            while s.ncores:
-                sleep(0.01)
-                assert time() < start + 5

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -85,7 +85,7 @@ services:
       - zk
 
   marathon:
-    image: mesosphere/marathon:v1.2.0-RC6
+    image: mesosphere/marathon:v1.2.0
     network_mode: host
     environment:
       MARATHON_MASTER: zk://127.0.0.1:2181/mesos

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import setup
 setup(name='dask_marathon',
       version='0.0.1',
       description='Deploy Dask on Marathon',
-      url='http://github.com/dask/dask-marathon/',
+      url='http://github.com/mrocklin/dask-marathon/',
       maintainer='Matthew Rocklin',
       maintainer_email='mrocklin@gmail.com',
       license='BSD',


### PR DESCRIPTION
This also skips all tests for the CLI (most of which appear to be copy-pasted
from dask/distributed) and also skip tests for adaptivity.