### PR TITLE
Add support for Marathon authentication

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -46,8 +46,8 @@ including docker containers, etc..
 
 .. code-block:: python
 
-   from dask_marathon import AdaptiveCluster
-   cluster = AdaptiveCluster(s, marathon_address='http://localhost:8080',
+   from dask_marathon import MarathonCluster
+   cluster = MarathonCluster(s, marathon_address='http://localhost:8080',
                              cpus=1, mem=1000, executable='dask-worker',
                              **kwargs)
 


### PR DESCRIPTION
`auth_token` was added in `marathon-python==0.8.7`. The `__init__` is getting a bit cluttered, but I wasn't sure if you actually want to have users pass in a `MarathonClient` object themselves.